### PR TITLE
Renamed Context.slot to Context.contextHolder

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -86,7 +86,6 @@ public abstract class AbstractBlockChain {
 
     /** Keeps a map of block hashes to StoredBlocks. */
     private final BlockStore blockStore;
-    private final Context context;
 
     /**
      * Tracks the top of the best known chain.<p>
@@ -150,11 +149,6 @@ public abstract class AbstractBlockChain {
         this.params = params;
         this.listeners = new CopyOnWriteArrayList<ListenerRegistration<BlockChainListener>>();
         for (BlockChainListener l : listeners) addListener(l, Threading.SAME_THREAD);
-        context = new Context();
-    }
-
-    public Context getContext() {
-        return context;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/BlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/BlockChain.java
@@ -46,6 +46,7 @@ public class BlockChain extends AbstractBlockChain {
      */
     public BlockChain(NetworkParameters params, Wallet wallet, BlockStore blockStore) throws BlockStoreException {
         this(params, new ArrayList<BlockChainListener>(), blockStore);
+        Context.getOrCreate();
         if (wallet != null)
             addWallet(wallet);
     }

--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -1,5 +1,10 @@
 package org.bitcoinj.core;
 
+import org.slf4j.*;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
 /**
  * The Context object holds various objects that are scoped to a specific instantiation of bitcoinj for a specific
  * network. You can get an instance of this class through {@link AbstractBlockChain#getContext()}. At the momemnt it
@@ -7,10 +12,73 @@ package org.bitcoinj.core;
  * other global configuration of use.
  */
 public class Context {
+    private static final Logger log = LoggerFactory.getLogger(Context.class);
     protected TxConfidenceTable confidenceTable;
 
-    protected Context() {
+    /**
+     * Creates a new context object. For now, this will be done for you by the framework. Eventually you will be
+     * expected to do this yourself in the same manner as fetching a NetworkParameters object (at the start of your app).
+     */
+    public Context() {
         confidenceTable = new TxConfidenceTable();
+        lastConstructed = this;
+        // We may already have a context in our TLS slot. This can happen a lot during unit tests, so just ignore it.
+        slot.set(this);
+    }
+
+    private static volatile Context lastConstructed;
+    private static final ThreadLocal<Context> slot = new ThreadLocal<Context>();
+
+    /**
+     * Returns the current context that is associated with the <b>calling thread</b>. BitcoinJ is an API that has thread
+     * affinity: much like OpenGL it expects each thread that accesses it to have been configured with a global Context
+     * object. This method returns that. Note that to help you develop, this method will <i>also</i> propagate whichever
+     * context was created last onto the current thread, if it's missing. However it will print an error when doing so
+     * because propagation of contexts is meant to be done manually: this is so two libraries or subsystems that
+     * independently use bitcoinj (or possibly alt coin forks of it) can operate correctly.
+     *
+     * @throws java.lang.IllegalStateException if no context exists at all.
+     */
+    public static Context get() {
+        Context tls = slot.get();
+        if (tls == null) {
+            if (lastConstructed == null)
+                throw new IllegalStateException("You must construct a Context object before using bitcoinj!");
+            slot.set(lastConstructed);
+            log.error("Performing thread fixup: you are accessing bitcoinj via a thread that has not had any context set on it.");
+            log.error("This error has been corrected for, but doing this makes your app less robust.");
+            log.error("You should use Context.propagate() or a ContextPropagatingThreadFactory.");
+            log.error("Please refer to the user guide for more information about this.");
+            // TODO: Actually write the user guide section about this.
+            // TODO: If the above TODO makes it past the 0.13 release, kick Mike and tell him he sucks.
+            return lastConstructed;
+        } else {
+            return tls;
+        }
+    }
+
+    // A temporary internal shim designed to help us migrate internally in a way that doesn't wreck source compatibility.
+    static Context getOrCreate() {
+        try {
+            return get();
+        } catch (IllegalStateException e) {
+            log.warn("Implicitly creating context. This is a migration step and this message will eventually go away.");
+            new Context();
+            return slot.get();
+        }
+    }
+
+    /**
+     * Sets the given context as the current thread context. You should use this if you create your own threads that
+     * want to create core BitcoinJ objects. Generally, if a class can accept a Context in its constructor and might
+     * be used (even indirectly) by a thread, you will want to call this first. Your task may be simplified by using
+     * a {@link org.bitcoinj.utils.ContextPropagatingThreadFactory}.
+     *
+     * @throws java.lang.IllegalStateException if this thread already has a context
+     */
+    public static void propagate(Context context) {
+        checkState(slot.get() == null);
+        slot.set(checkNotNull(context));
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -7,7 +7,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 /**
  * The Context object holds various objects that are scoped to a specific instantiation of bitcoinj for a specific
- * network. You can get an instance of this class through {@link AbstractBlockChain#getContext()}. At the momemnt it
+ * network. You can get an instance of this class through calling {@link #get()}. At the moment it
  * only contains a {@link org.bitcoinj.core.TxConfidenceTable} but in future it will likely contain file paths and
  * other global configuration of use.
  */

--- a/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
@@ -21,7 +21,7 @@ import org.bitcoinj.script.Script;
 import org.bitcoinj.script.Script.VerifyFlag;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.FullPrunedBlockStore;
-import org.bitcoinj.utils.DaemonThreadFactory;
+import org.bitcoinj.utils.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -123,7 +123,7 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
     
     // TODO: execute in order of largest transaction (by input count) first
     ExecutorService scriptVerificationExecutor = Executors.newFixedThreadPool(
-            Runtime.getRuntime().availableProcessors(), new DaemonThreadFactory());
+            Runtime.getRuntime().availableProcessors(), new ContextPropagatingThreadFactory("Script verification"));
 
     /** A job submitted to the executor which verifies signatures. */
     private static class Verifier implements Callable<VerificationException> {

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -121,6 +121,12 @@ public class Peer extends PeerSocketHandler {
     // It is important to avoid a nasty edge case where we can end up with parallel chain downloads proceeding
     // simultaneously if we were to receive a newly solved block whilst parts of the chain are streaming to us.
     private final HashSet<Sha256Hash> pendingBlockDownloads = new HashSet<Sha256Hash>();
+    // Keep references to TransactionConfidence objects for transactions that were announced by a remote peer, but
+    // which we haven't downloaded yet. These objects are de-duplicated by the TxConfidenceTable class.
+    // Once the tx is downloaded (by some peer), the Transaction object that is created will have a reference to
+    // the confidence object held inside it, and it's then up to the event listeners that receive the Transaction
+    // to keep it pinned to the root set if they care about this data.
+    private final HashSet<TransactionConfidence> pendingTxDownloads = new HashSet<TransactionConfidence>();
     // The lowest version number we're willing to accept. Lower than this will result in an immediate disconnect.
     private volatile int vMinProtocolVersion = Pong.MIN_PROTOCOL_VERSION;
     // When an API user explicitly requests a block or transaction from a peer, the InventoryItem is put here
@@ -595,19 +601,23 @@ public class Peer extends PeerSocketHandler {
         }
     }
 
-    private void processTransaction(Transaction tx) throws VerificationException {
+    private void processTransaction(final Transaction tx) throws VerificationException {
         // Check a few basic syntax issues to ensure the received TX isn't nonsense.
         tx.verify();
-        final Transaction fTx;
         lock.lock();
         try {
             log.debug("{}: Received tx {}", getAddress(), tx.getHashAsString());
-            // We may get back a different transaction object.
-            fTx = context.getConfidenceTable().seen(tx, getAddress());
             // Label the transaction as coming in from the P2P network (as opposed to being created by us, direct import,
             // etc). This helps the wallet decide how to risk analyze it later.
-            fTx.getConfidence().setSource(TransactionConfidence.Source.NETWORK);
-            if (maybeHandleRequestedData(fTx)) {
+            //
+            // Additionally, by invoking tx.getConfidence(), this tx now pins the confidence data into the heap, meaning
+            // we can stop holding a reference to the confidence object ourselves. It's up to event listeners on the
+            // Peer to stash the tx object somewhere if they want to keep receiving updates about network propagation
+            // and so on.
+            TransactionConfidence confidence = tx.getConfidence();
+            confidence.setSource(TransactionConfidence.Source.NETWORK);
+            pendingTxDownloads.remove(confidence);
+            if (maybeHandleRequestedData(tx)) {
                 return;
             }
             if (currentFilteredBlock != null) {
@@ -623,7 +633,7 @@ public class Peer extends PeerSocketHandler {
             // It's a broadcast transaction. Tell all wallets about this tx so they can check if it's relevant or not.
             for (final Wallet wallet : wallets) {
                 try {
-                    if (wallet.isPendingTransactionRelevant(fTx)) {
+                    if (wallet.isPendingTransactionRelevant(tx)) {
                         if (vDownloadTxDependencies) {
                             // This transaction seems interesting to us, so let's download its dependencies. This has
                             // several purposes: we can check that the sender isn't attacking us by engaging in protocol
@@ -640,15 +650,14 @@ public class Peer extends PeerSocketHandler {
                             // through transactions that have confirmed, as getdata on the remote peer also checks
                             // relay memory not only the mempool. Unfortunately we have no way to know that here. In
                             // practice it should not matter much.
-                            Futures.addCallback(downloadDependencies(fTx), new FutureCallback<List<Transaction>>() {
+                            Futures.addCallback(downloadDependencies(tx), new FutureCallback<List<Transaction>>() {
                                 @Override
                                 public void onSuccess(List<Transaction> dependencies) {
                                     try {
                                         log.info("{}: Dependency download complete!", getAddress());
-                                        wallet.receivePending(fTx, dependencies);
+                                        wallet.receivePending(tx, dependencies);
                                     } catch (VerificationException e) {
-                                        log.error("{}: Wallet failed to process pending transaction {}", getAddress(),
-                                                fTx.getHashAsString());
+                                        log.error("{}: Wallet failed to process pending transaction {}", getAddress(), tx.getHash());
                                         log.error("Error was: ", e);
                                         // Not much more we can do at this point.
                                     }
@@ -656,13 +665,13 @@ public class Peer extends PeerSocketHandler {
 
                                 @Override
                                 public void onFailure(Throwable throwable) {
-                                    log.error("Could not download dependencies of tx {}", fTx.getHashAsString());
+                                    log.error("Could not download dependencies of tx {}", tx.getHashAsString());
                                     log.error("Error was: ", throwable);
                                     // Not much more we can do at this point.
                                 }
                             });
                         } else {
-                            wallet.receivePending(fTx, null);
+                            wallet.receivePending(tx, null);
                         }
                     }
                 } catch (VerificationException e) {
@@ -679,7 +688,7 @@ public class Peer extends PeerSocketHandler {
             registration.executor.execute(new Runnable() {
                 @Override
                 public void run() {
-                    registration.listener.onTransaction(Peer.this, fTx);
+                    registration.listener.onTransaction(Peer.this, tx);
                 }
             });
         }
@@ -732,23 +741,13 @@ public class Peer extends PeerSocketHandler {
         // We want to recursively grab its dependencies. This is so listeners can learn important information like
         // whether a transaction is dependent on a timelocked transaction or has an unexpectedly deep dependency tree
         // or depends on a no-fee transaction.
-        //
-        // Firstly find any that are already in the memory pool so if they weren't garbage collected yet, they won't
-        // be deleted. Use COW sets to make unit tests deterministic and because they are small. It's slower for
-        // the case of transactions with tons of inputs.
-        Set<Transaction> dependencies = new CopyOnWriteArraySet<Transaction>();
+
+        // We may end up requesting transactions that we've already downloaded and thrown away here.
         Set<Sha256Hash> needToRequest = new CopyOnWriteArraySet<Sha256Hash>();
         for (TransactionInput input : tx.getInputs()) {
             // There may be multiple inputs that connect to the same transaction.
-            Sha256Hash hash = input.getOutpoint().getHash();
-            Transaction dep = context.getConfidenceTable().get(hash);
-            if (dep == null) {
-                needToRequest.add(hash);
-            } else {
-                dependencies.add(dep);
-            }
+            needToRequest.add(input.getOutpoint().getHash());
         }
-        results.addAll(dependencies);
         lock.lock();
         try {
             // Build the request for the missing dependencies.
@@ -763,10 +762,6 @@ public class Peer extends PeerSocketHandler {
                 req.future = SettableFuture.create();
                 futures.add(req.future);
                 getDataFutures.add(req);
-            }
-            // The transactions we already grabbed out of the mempool must still be considered by the code below.
-            for (Transaction dep : dependencies) {
-                futures.add(Futures.immediateFuture(dep));
             }
             ListenableFuture<List<Transaction>> successful = Futures.successfulAsList(futures);
             Futures.addCallback(successful, new FutureCallback<List<Transaction>>() {
@@ -1063,15 +1058,18 @@ public class Peer extends PeerSocketHandler {
             // peers run at different speeds. However to conserve bandwidth on mobile devices we try to only download a
             // transaction once. This means we can miss broadcasts if the peer disconnects between sending us an inv and
             // sending us the transaction: currently we'll never try to re-fetch after a timeout.
-            if (context.getConfidenceTable().maybeWasSeen(item.hash)) {
+            //
+            // The line below can trigger confidence listeners.
+            TransactionConfidence conf = context.getConfidenceTable().seen(item.hash, this.getAddress());
+            if (conf.numBroadcastPeers() > 1) {
                 // Some other peer already announced this so don't download.
                 it.remove();
             } else {
                 log.debug("{}: getdata on tx {}", getAddress(), item.hash);
                 getdata.addItem(item);
+                // Register with the garbage collector that we care about the confidence data for a while.
+                pendingTxDownloads.add(conf);
             }
-            // This can trigger transaction confidence listeners.
-            context.getConfidenceTable().seen(item.hash, this.getAddress());
         }
 
         // If we are requesting filteredblocks we have to send a ping after the getdata so that we have a clear

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -519,20 +519,13 @@ public class PeerGroup implements TransactionBroadcaster {
             Iterator<InventoryItem> it = items.iterator();
             while (it.hasNext()) {
                 InventoryItem item = it.next();
-                // Check the confidence pool first.
-                Transaction tx = chain != null ? Context.get().getConfidenceTable().get(item.hash) : null;
-                if (tx != null) {
+                // Check the wallets.
+                for (Wallet w : wallets) {
+                    Transaction tx = w.getTransaction(item.hash);
+                    if (tx == null) continue;
                     transactions.add(tx);
                     it.remove();
-                } else {
-                    // Check the wallets.
-                    for (Wallet w : wallets) {
-                        tx = w.getTransaction(item.hash);
-                        if (tx == null) continue;
-                        transactions.add(tx);
-                        it.remove();
-                        break;
-                    }
+                    break;
                 }
             }
             return transactions;

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1131,15 +1131,14 @@ public class Transaction extends ChildMessage implements Serializable {
 
     /** Returns the confidence object that is owned by this transaction object. */
     public synchronized TransactionConfidence getConfidence() {
-        if (confidence == null) {
-            confidence = new TransactionConfidence(getHash());
-        }
+        if (confidence == null)
+            confidence = Context.get().getConfidenceTable().getOrCreate(getHash()) ;
         return confidence;
     }
 
     /** Check if the transaction has a known confidence */
     public synchronized boolean hasConfidence() {
-        return confidence != null && confidence.getConfidenceType() != TransactionConfidence.ConfidenceType.UNKNOWN;
+        return getConfidence().getConfidenceType() != TransactionConfidence.ConfidenceType.UNKNOWN;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
@@ -17,18 +17,14 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.collect.Sets;
-import org.bitcoinj.utils.ListenerRegistration;
-import org.bitcoinj.utils.Threading;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.collect.*;
+import com.google.common.util.concurrent.*;
+import org.bitcoinj.utils.*;
 
-import javax.annotation.Nullable;
-import java.io.Serializable;
-import java.util.ListIterator;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Executor;
+import javax.annotation.*;
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.*;
 
 import static com.google.common.base.Preconditions.*;
 
@@ -261,8 +257,7 @@ public class TransactionConfidence implements Serializable {
     /**
      * Called by a {@link Peer} when a transaction is pending and announced by a peer. The more peers announce the
      * transaction, the more peers have validated it (assuming your internet connection is not being intercepted).
-     * If confidence is currently unknown, sets it to {@link ConfidenceType#PENDING}. Listeners will be
-     * invoked in this case.
+     * If confidence is currently unknown, sets it to {@link ConfidenceType#PENDING}.
      *
      * @param address IP address of the peer, used as a proxy for identity.
      */

--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -159,6 +159,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
     // A list of scripts watched by this wallet.
     private Set<Script> watchedScripts;
 
+    protected final Context context;
     protected final NetworkParameters params;
 
     @Nullable private Sha256Hash lastBlockSeenHash;
@@ -256,6 +257,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
     // TODO: When this class moves to the Wallet package, along with the protobuf serializer, then hide this.
     /** For internal use only. */
     public Wallet(NetworkParameters params, KeyChainGroup keyChainGroup) {
+        this.context = Context.getOrCreate();
         this.params = checkNotNull(params);
         this.keychain = checkNotNull(keyChainGroup);
         if (params == UnitTestParams.get())
@@ -2064,7 +2066,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
         while (!work.isEmpty()) {
             final Transaction tx = work.poll();
             log.warn("TX {} killed{}", tx.getHashAsString(),
-                    overridingTx != null ? "by " + overridingTx.getHashAsString() : "");
+                    overridingTx != null ? " by " + overridingTx.getHashAsString() : "");
             log.warn("Disconnecting each input and moving connected transactions.");
             // TX could be pending (finney attack), or in unspent/spent (coinbase killed by reorg).
             pending.remove(tx.getHash());

--- a/core/src/main/java/org/bitcoinj/net/BlockingClient.java
+++ b/core/src/main/java/org/bitcoinj/net/BlockingClient.java
@@ -16,22 +16,18 @@
 
 package org.bitcoinj.net;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
-import org.slf4j.LoggerFactory;
+import com.google.common.util.concurrent.*;
+import org.bitcoinj.core.*;
+import org.slf4j.*;
 
-import javax.annotation.Nullable;
-import javax.net.SocketFactory;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.net.SocketAddress;
-import java.nio.ByteBuffer;
-import java.util.Set;
+import javax.annotation.*;
+import javax.net.*;
+import java.io.*;
+import java.net.*;
+import java.nio.*;
+import java.util.*;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Preconditions.*;
 
 /**
  * <p>Creates a simple connection to a server using a {@link StreamParser} to process data.</p>
@@ -71,9 +67,11 @@ public class BlockingClient implements MessageWriteTarget {
         dbuf = ByteBuffer.allocateDirect(Math.min(Math.max(parser.getMaxMessageSize(), BUFFER_SIZE_LOWER_BOUND), BUFFER_SIZE_UPPER_BOUND));
         parser.setWriteTarget(this);
         socket = socketFactory.createSocket();
+        final Context context = Context.get();
         Thread t = new Thread() {
             @Override
             public void run() {
+                Context.propagate(context);
                 if (clientSet != null)
                     clientSet.add(BlockingClient.this);
                 try {

--- a/core/src/main/java/org/bitcoinj/net/NioClientManager.java
+++ b/core/src/main/java/org/bitcoinj/net/NioClientManager.java
@@ -18,6 +18,7 @@ package org.bitcoinj.net;
 
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.*;
+import org.bitcoinj.utils.*;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
@@ -188,9 +189,7 @@ public class NioClientManager extends AbstractExecutionThreadService implements 
         return new Executor() {
             @Override
             public void execute(Runnable command) {
-                Thread thread = new Thread(command, "NioClientManager");
-                thread.setDaemon(true);
-                thread.start();
+                new ContextPropagatingThreadFactory("NioClientManager").newThread(command).start();
             }
         };
     }

--- a/core/src/main/java/org/bitcoinj/net/discovery/DnsDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/DnsDiscovery.java
@@ -67,9 +67,9 @@ public class DnsDiscovery extends MultiplexingDiscovery {
         // Attempted workaround for reported bugs on Linux in which gethostbyname does not appear to be properly
         // thread safe and can cause segfaults on some libc versions.
         if (System.getProperty("os.name").toLowerCase().contains("linux"))
-            return Executors.newSingleThreadExecutor(new DaemonThreadFactory());
+            return Executors.newSingleThreadExecutor(new ContextPropagatingThreadFactory("DNS seed lookups"));
         else
-            return Executors.newFixedThreadPool(seeds.size(), new DaemonThreadFactory());
+            return Executors.newFixedThreadPool(seeds.size(), new DaemonThreadFactory("DNS seed lookups"));
     }
 
     /** Implements discovery from a single DNS host. */

--- a/core/src/main/java/org/bitcoinj/net/discovery/MultiplexingDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/MultiplexingDiscovery.java
@@ -18,7 +18,7 @@ package org.bitcoinj.net.discovery;
 
 import com.google.common.collect.Lists;
 import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.utils.DaemonThreadFactory;
+import org.bitcoinj.utils.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,7 +94,7 @@ public class MultiplexingDiscovery implements PeerDiscovery {
     }
 
     protected ExecutorService createExecutor() {
-        return Executors.newFixedThreadPool(seeds.size(), new DaemonThreadFactory());
+        return Executors.newFixedThreadPool(seeds.size(), new ContextPropagatingThreadFactory("Multiplexing discovery"));
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/net/discovery/TorDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/TorDiscovery.java
@@ -16,44 +16,22 @@
 
 package org.bitcoinj.net.discovery;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import org.bitcoinj.core.NetworkParameters;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
-import com.subgraph.orchid.Circuit;
-import com.subgraph.orchid.RelayCell;
-import com.subgraph.orchid.Router;
-import com.subgraph.orchid.TorClient;
-import com.subgraph.orchid.circuits.path.CircuitPathChooser;
-import com.subgraph.orchid.data.HexDigest;
-import com.subgraph.orchid.data.exitpolicy.ExitTarget;
+import com.google.common.collect.*;
+import com.google.common.util.concurrent.*;
+import com.subgraph.orchid.*;
+import com.subgraph.orchid.circuits.path.*;
+import com.subgraph.orchid.data.*;
+import com.subgraph.orchid.data.exitpolicy.*;
+import org.bitcoinj.core.*;
+import org.bitcoinj.utils.*;
+import org.slf4j.*;
 
-import org.bitcoinj.utils.DaemonThreadFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.net.*;
+import java.util.*;
+import java.util.concurrent.*;
 
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-
-import static java.util.Collections.singleton;
+import static com.google.common.base.Preconditions.*;
+import static java.util.Collections.*;
 
 /**
  * <p>Supports peer discovery through Tor.</p>
@@ -254,7 +232,7 @@ public class TorDiscovery implements PeerDiscovery {
 
     private synchronized void createThreadPool(int size) {
         threadPool = MoreExecutors.listeningDecorator(
-                Executors.newFixedThreadPool(size, new DaemonThreadFactory()));
+                Executors.newFixedThreadPool(size, new ContextPropagatingThreadFactory("Tor DNS discovery")));
     }
 
     private InetAddress lookup(Circuit circuit, String seed) throws UnknownHostException {

--- a/core/src/main/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/core/src/main/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -81,6 +81,7 @@ public class TestWithNetworkConnections {
         BriefLogFormatter.init();
 
         unitTestParams = UnitTestParams.get();
+        new Context();
         Wallet.SendRequest.DEFAULT_FEE_PER_KB = Coin.ZERO;
         this.blockStore = blockStore;
         // Allow subclasses to override the wallet object with their own.

--- a/core/src/main/java/org/bitcoinj/testing/TestWithPeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/testing/TestWithPeerGroup.java
@@ -25,7 +25,7 @@ import org.bitcoinj.params.UnitTestParams;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import com.google.common.base.Preconditions;
-import org.bitcoinj.utils.DaemonThreadFactory;
+import org.bitcoinj.utils.*;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.*;
@@ -98,7 +98,7 @@ public class TestWithPeerGroup extends TestWithNetworkConnections {
         return new PeerGroup(unitTestParams, blockChain, manager) {
             @Override
             protected ListeningScheduledExecutorService createPrivateExecutor() {
-                return MoreExecutors.listeningDecorator(new ScheduledThreadPoolExecutor(1, new DaemonThreadFactory("PeerGroup test thread")) {
+                return MoreExecutors.listeningDecorator(new ScheduledThreadPoolExecutor(1, new ContextPropagatingThreadFactory("PeerGroup test thread")) {
                     @Override
                     public ScheduledFuture<?> schedule(final Runnable command, final long delay, final TimeUnit unit) {
                         if (!blockJobs)

--- a/core/src/main/java/org/bitcoinj/utils/ContextPropagatingThreadFactory.java
+++ b/core/src/main/java/org/bitcoinj/utils/ContextPropagatingThreadFactory.java
@@ -1,0 +1,33 @@
+package org.bitcoinj.utils;
+
+import org.bitcoinj.core.*;
+
+import java.util.concurrent.*;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A {@link java.util.concurrent.ThreadFactory} that propagates a {@link org.bitcoinj.core.Context} from the creating
+ * thread into the new thread. This factory creates daemon threads.
+ */
+public class ContextPropagatingThreadFactory implements ThreadFactory {
+    private final String name;
+
+    public ContextPropagatingThreadFactory(String name) {
+        this.name = checkNotNull(name);
+    }
+
+    @Override
+    public Thread newThread(final Runnable r) {
+        final Context context = Context.get();
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Context.propagate(context);
+                r.run();
+            }
+        }, name);
+        thread.setDaemon(true);
+        return thread;
+    }
+}

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -58,10 +58,10 @@ public class ChainSplitTest {
         Utils.setMockClock(); // Use mock clock
         Wallet.SendRequest.DEFAULT_FEE_PER_KB = Coin.ZERO;
         unitTestParams = UnitTestParams.get();
+        blockStore = new MemoryBlockStore(unitTestParams);
         wallet = new Wallet(unitTestParams);
         ECKey key1 = wallet.freshReceiveKey();
         ECKey key2 = wallet.freshReceiveKey();
-        blockStore = new MemoryBlockStore(unitTestParams);
         chain = new BlockChain(unitTestParams, wallet, blockStore);
         coinsTo = key1.toAddress(unitTestParams);
         coinsTo2 = key2.toAddress(unitTestParams);
@@ -204,7 +204,7 @@ public class ChainSplitTest {
         chain.add(b3);
         chain.add(b4);
         // b4 causes a re-org that should make our spend go pending again.
-        assertEquals(valueOf(40, 0), wallet.getBalance());
+        assertEquals(valueOf(40, 0), wallet.getBalance(Wallet.BalanceType.ESTIMATED));
         assertEquals(ConfidenceType.PENDING, spend.getConfidence().getConfidenceType());
     }
 
@@ -339,9 +339,7 @@ public class ChainSplitTest {
         wallet.addEventListener(new AbstractWalletEventListener() {
             @Override
             public void onTransactionConfidenceChanged(Wallet wallet, Transaction tx) {
-                super.onTransactionConfidenceChanged(wallet, tx);
-                if (tx.getConfidence().getConfidenceType() ==
-                        TransactionConfidence.ConfidenceType.DEAD) {
+                if (tx.getConfidence().getConfidenceType() == TransactionConfidence.ConfidenceType.DEAD) {
                     eventDead[0] = tx;
                     eventReplacement[0] = tx.getConfidence().getOverridingTransaction();
                 }

--- a/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -375,8 +375,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         // Peer 2 advertises the tx but does not receive it yet.
         inbound(p2, inv);
         assertTrue(outbound(p2) instanceof GetDataMessage);
-        assertEquals(0, tx.getConfidence().numBroadcastPeers());
-        assertTrue(Context.get().getConfidenceTable().maybeWasSeen(tx.getHash()));
+        assertEquals(1, tx.getConfidence().numBroadcastPeers());
         assertNull(event[0]);
         // Peer 1 advertises the tx, we don't do anything as it's already been requested.
         inbound(p1, inv);

--- a/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -376,7 +376,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         inbound(p2, inv);
         assertTrue(outbound(p2) instanceof GetDataMessage);
         assertEquals(0, tx.getConfidence().numBroadcastPeers());
-        assertTrue(blockChain.getContext().getConfidenceTable().maybeWasSeen(tx.getHash()));
+        assertTrue(Context.get().getConfidenceTable().maybeWasSeen(tx.getHash()));
         assertNull(event[0]);
         // Peer 1 advertises the tx, we don't do anything as it's already been requested.
         inbound(p1, inv);

--- a/core/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -292,7 +292,7 @@ public class PeerTest extends TestWithNetworkConnections {
         GetDataMessage message = (GetDataMessage)outbound(writeTarget);
         assertEquals(1, message.getItems().size());
         assertEquals(tx.getHash(), message.getItems().get(0).hash);
-        assertTrue(confidenceTable.maybeWasSeen(tx.getHash()));
+        assertNotEquals(0, tx.getConfidence().numBroadcastPeers());
 
         // Advertising to peer2 results in no getdata message.
         inbound(writeTarget2, inv);
@@ -554,7 +554,7 @@ public class PeerTest extends TestWithNetworkConnections {
             }
         }, Threading.SAME_THREAD);
 
-        // Make the some fake transactions in the following graph:
+        // Make some fake transactions in the following graph:
         //   t1 -> t2 -> [t5]
         //      -> t3 -> t4 -> [t6]
         //      -> [t7]
@@ -601,10 +601,6 @@ public class PeerTest extends TestWithNetworkConnections {
         assertEquals(t3.getHash(), getdata.getItems().get(1).hash);
         assertEquals(someHash, getdata.getItems().get(2).hash);
         assertEquals(anotherHash, getdata.getItems().get(3).hash);
-        // For some random reason, t4 is delivered at this point before it's needed - perhaps it was a Bloom filter
-        // false positive. We do this to check that the mempool is being checked for seen transactions before
-        // requesting them.
-        inbound(writeTarget, t4);
         // Deliver the requested transactions.
         inbound(writeTarget, t2);
         inbound(writeTarget, t3);
@@ -621,6 +617,10 @@ public class PeerTest extends TestWithNetworkConnections {
         notFound.addItem(new InventoryItem(InventoryItem.Type.Transaction, t5));
         inbound(writeTarget, notFound);
         assertFalse(futures.isDone());
+        // Request t4 ...
+        getdata = (GetDataMessage) outbound(writeTarget);
+        assertEquals(t4.getHash(), getdata.getItems().get(0).hash);
+        inbound(writeTarget, t4);
         // Continue to explore the t4 branch and ask for t6, which is in the chain.
         getdata = (GetDataMessage) outbound(writeTarget);
         assertEquals(t6, getdata.getItems().get(0).hash);

--- a/core/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -78,7 +78,7 @@ public class PeerTest extends TestWithNetworkConnections {
     public void setUp() throws Exception {
         super.setUp();
 
-        confidenceTable = blockChain.getContext().getConfidenceTable();
+        confidenceTable = Context.get().getConfidenceTable();
         VersionMessage ver = new VersionMessage(unitTestParams, 100);
         InetSocketAddress address = new InetSocketAddress("127.0.0.1", 4000);
         peer = new Peer(unitTestParams, ver, new PeerAddress(address), blockChain);
@@ -601,7 +601,6 @@ public class PeerTest extends TestWithNetworkConnections {
         assertEquals(t3.getHash(), getdata.getItems().get(1).hash);
         assertEquals(someHash, getdata.getItems().get(2).hash);
         assertEquals(anotherHash, getdata.getItems().get(3).hash);
-        long nonce = -1;
         // For some random reason, t4 is delivered at this point before it's needed - perhaps it was a Bloom filter
         // false positive. We do this to check that the mempool is being checked for seen transactions before
         // requesting them.

--- a/core/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -73,7 +73,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
     public void fourPeers() throws Exception {
         InboundMessageQueuer[] channels = { connectPeer(1), connectPeer(2), connectPeer(3), connectPeer(4) };
         Transaction tx = new Transaction(params);
-        TransactionBroadcast broadcast = new TransactionBroadcast(peerGroup, blockChain.getContext(), tx);
+        TransactionBroadcast broadcast = new TransactionBroadcast(peerGroup, tx);
         final AtomicDouble lastProgress = new AtomicDouble();
         broadcast.setProgressCallback(new TransactionBroadcast.ProgressCallback() {
             @Override
@@ -102,9 +102,8 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         assertEquals(0.0, lastProgress.get(), 0.0);
         inbound(channels[1], InventoryMessage.with(tx));
         pingAndWait(channels[1]);
+        future.get();
         Threading.waitForUserCode();
-        // FIXME flaky test - future is not handled on user thread
-        assertTrue(future.isDone());
         assertEquals(1.0, lastProgress.get(), 0.0);
     }
 
@@ -112,7 +111,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
     public void rejectHandling() throws Exception {
         InboundMessageQueuer[] channels = { connectPeer(0), connectPeer(1), connectPeer(2), connectPeer(3), connectPeer(4) };
         Transaction tx = new Transaction(params);
-        TransactionBroadcast broadcast = new TransactionBroadcast(peerGroup, blockChain.getContext(), tx);
+        TransactionBroadcast broadcast = new TransactionBroadcast(peerGroup, tx);
         ListenableFuture<Transaction> future = broadcast.broadcast();
         // 0 and 3 are randomly selected to receive the broadcast.
         assertEquals(tx, outbound(channels[1]));

--- a/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
+++ b/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
@@ -48,7 +48,11 @@ public class SendMoneyController {
         try {
             Coin amount = Coin.parseCoin(amountEdit.getText());
             Address destination = new Address(Main.params, address.getText());
-            Wallet.SendRequest req = Wallet.SendRequest.to(destination, amount);
+            Wallet.SendRequest req;
+            if (amount.equals(Main.bitcoin.wallet().getBalance()))
+                req = Wallet.SendRequest.emptyWallet(destination);
+            else
+                req = Wallet.SendRequest.to(destination, amount);
             req.aesKey = aesKey;
             sendResult = Main.bitcoin.wallet().sendCoins(req);
             Futures.addCallback(sendResult.broadcastComplete, new FutureCallback<Transaction>() {


### PR DESCRIPTION
I tried to review your changes on Context and came up with new names. I also tried to override ThreadLocal's initialValue() like this:

```
if (lastHold == null)
   throw new IllegalArgumentException("You must build a context first to use bitcoinj!");
else{
  log.error("Thread fixup")
  log.error("You should propagate a context in your thread")
  return lastHold
}
```

without knowing too much about volatile, it throws IllegalStateException in TransactionBroadcasterTest. Is this a bug in the design or JUnit's fault? I'd be happy to try to run the necessary tests in different threads using ContextPropagatingThreadFactory, if that's a solution. 
